### PR TITLE
SP：iPhone5でのカラム落ち修正しました

### DIFF
--- a/css/style-common.css
+++ b/css/style-common.css
@@ -185,14 +185,13 @@ header nav h1 a:visited {
 .web-product .site-list {
   width: 101%;
 }
-.web-product .site-list li a {
-  display: inline-block;
+.web-product .site-list li {
   float: left;
-  height: 240px;
+  height: 270px;
   width: 24%;
-  margin: 0 1% 55px 0;
+  margin: 0 12px 55px 0;
 }
-.web-product .site-list li a img {
+.web-product .site-list li img {
   border: 1px solid #cecece;
   -moz-transition: transform 0.3s linear 0s;
   -o-transition: transform 0.3s linear 0s;
@@ -201,14 +200,14 @@ header nav h1 a:visited {
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
-.web-product .site-list li a img:hover {
+.web-product .site-list li img:hover {
   -moz-transform: scale(1.02);
   -ms-transform: scale(1.02);
   -o-transform: scale(1.02);
   -webkit-transform: scale(1.02);
   transform: scale(1.02);
 }
-.web-product .site-list li a h2 {
+.web-product .site-list li h2 {
   margin: 2px 0 0;
   font-size: 1.4rem;
   font-weight: normal;
@@ -497,16 +496,17 @@ footer {
     margin: 20px auto;
   }
   .web-product .site-list {
-    width: 104%;
+    width: 100%;
+    margin: auto;
+    overflow: hidden;
   }
-  .web-product .site-list li a {
-    display: inline-block;
-    float: left;
-    height: 165px;
-    width: 46%;
-    margin: 0 13px 25px 0;
+  .web-product .site-list li {
+    height: 190px;
+    width: 50%;
+    margin: 0;
+    padding: 5px;
   }
-  .web-product .site-list li a h2 {
+  .web-product .site-list li h2 {
     margin: 1px 0 0;
     font-size: 1.2rem;
   }

--- a/scss/style-common.scss
+++ b/scss/style-common.scss
@@ -165,12 +165,11 @@ header {
 	margin: 30px 0;
 	.site-list {
 		width: 101%;
-		li a {
-			display: inline-block;
+		li {
 			float: left;
-			height: 240px;
+			height: 270px;
 			width: 24%;
-			margin: 0 1% 55px 0;
+			margin: 0 12px 55px 0;
 			img {
 				border: 1px solid #cecece;
 				-moz-transition: transform 0.3s linear 0s;
@@ -478,13 +477,14 @@ header {
 	width: 90%;
 	margin: 20px auto;
 		.site-list {
-		width: 104%;
-		li a {
-			display: inline-block;
-			float: left;
-			height: 165px;
-			width: 46%;
-			margin: 0 13px 25px 0;
+			width: 100%;
+			margin: auto;
+			overflow: hidden;
+			li {
+				height: 190px;
+				width: 50%;
+				margin: 0;
+				padding: 5px;
 			h2 {
 				margin: 1px 0 0;
 				font-size: 1.2rem;


### PR DESCRIPTION
issue No. #17

iPhone5でのカラム落ち修正しました。
（他、iPhone6、iPhone6 Plus、Galaxy、Nexus環境でも確認済）

**Before**
<img width="315" alt="2017-10-21 17 16 04" src="https://user-images.githubusercontent.com/31947373/31850322-01d3a172-b68b-11e7-9e12-0d261d9b9c23.png">
↓
**After**
<img width="310" alt="2017-10-21 18 02 38" src="https://user-images.githubusercontent.com/31947373/31850323-0f07429a-b68b-11e7-8109-13cd20cba0fb.png">



SP修正のため、PC用のCSSも修正が入ってます。
https://github.com/Shizulu/mgallery/commit/91e9e94bb729db94a296b0d6dfdced77b4a393e6

レビューをお願いいたします。
