### PR TITLE
PC：window幅が少しでも狭いとカラム落ちしてしまう箇所修正（SPのカラム落ちを修正したら起きた現象）

### DIFF
--- a/css/style-common.css
+++ b/css/style-common.css
@@ -180,6 +180,7 @@ header nav h1 a:visited {
 /*web-site
 ------------------------------------------------------------*/
 .web-product {
+  width: 100%;
   margin: 30px 0;
 }
 .web-product .site-list {
@@ -189,7 +190,7 @@ header nav h1 a:visited {
   float: left;
   height: 270px;
   width: 24%;
-  margin: 0 12px 55px 0;
+  margin: 0 1% 55px 0;
 }
 .web-product .site-list li img {
   border: 1px solid #cecece;

--- a/scss/style-common.scss
+++ b/scss/style-common.scss
@@ -162,6 +162,7 @@ header {
 /*web-site
 ------------------------------------------------------------*/
 .web-product {
+	width: 100%;
 	margin: 30px 0;
 	.site-list {
 		width: 101%;
@@ -169,7 +170,7 @@ header {
 			float: left;
 			height: 270px;
 			width: 24%;
-			margin: 0 12px 55px 0;
+			margin: 0 1% 55px 0;
 			img {
 				border: 1px solid #cecece;
 				-moz-transition: transform 0.3s linear 0s;


### PR DESCRIPTION
issue No.#20

修正しました！
さっきのSPの修正の際に、PC側のCSSも変更する必要があり
その時にmarginをpx指定に変更していたのが原因でした。

**Before**
<img width="1384" alt="2017-10-21 18 27 11" src="https://user-images.githubusercontent.com/31947373/31850556-2e36419e-b68f-11e7-9505-a48b702afd6f.png">
↓
**After**
<img width="1310" alt="2017-10-21 18 39 45" src="https://user-images.githubusercontent.com/31947373/31850566-4e0c6548-b68f-11e7-9a8b-2091a183678d.png">

https://github.com/Shizulu/mgallery/commit/9bf95435229c3bc13d0d9e7d1915e2954dbde9cd

レビューをお願いいたします。
